### PR TITLE
Add a Macedonian translation of the bot's DM text.

### DIFF
--- a/server.js
+++ b/server.js
@@ -57,6 +57,7 @@ const messages = {
     `თქვენს ტვიტში როგორც მინიმუმ ერთ სურათს ალტერნატიული ტექსტი არ გააჩნია ${tweet}`,
   ms: tweet =>
     `Tweet anda mempunyai sekurang-kurangnya satu gambar tanpa deskripsi ${tweet}`,
+  mk: tweet => `Вашиот твит има барем една слика без описен текст ${tweet}`,
   nb: tweet => `Din tweet har minst ett bilde uten beskrivelse ${tweet}`,
   ne: tweet => `तपाईंको ट्वीटमा कम्तिमा एउटा वर्णन बिनाको चित्र छ। ${tweet}`,
   nl: tweet =>


### PR DESCRIPTION
As far as I can tell, Twitter's API uses ISO 639-1 i.e. "alpha 2" language codes, and `mk` is the correct one for Macedonian.

If you'd like to be extra safe and double-check the API's returned language code, here's a tweet I wrote in Macedonian and which Twitter recognizes as such:
https://twitter.com/PredragGruevski/status/1509583425031880704

Thanks for running this bot and for putting the code on GitHub so I could contribute! ❤️